### PR TITLE
Implement CORS support to allow REST calls from browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test-results

--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,6 @@ deployment:
       - docker tag -f sidewinder-server tutum.co/robertfmurdock/sidewinder-server
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REPO
       - docker push tutum.co/robertfmurdock/sidewinder-server
-general:
-  artifacts:
-    - "test-results"
+test:
+  post:
+    - mv test-results $CIRCLE_TEST_REPORTS/junit

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,6 @@
 machine:
   services:
     - docker
-
 dependencies:
   pre:
     - docker info
@@ -14,3 +13,6 @@ deployment:
       - docker tag -f sidewinder-server tutum.co/robertfmurdock/sidewinder-server
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REPO
       - docker push tutum.co/robertfmurdock/sidewinder-server
+general:
+  artifacts:
+    - "test-results"

--- a/circle.yml
+++ b/circle.yml
@@ -14,4 +14,3 @@ deployment:
       - docker tag -f sidewinder-server tutum.co/robertfmurdock/sidewinder-server
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REPO
       - docker push tutum.co/robertfmurdock/sidewinder-server
-#      - curl -X POST $TUTUM_WEBHOOK

--- a/director.go
+++ b/director.go
@@ -75,6 +75,7 @@ func decodeDeviceDocument(request *http.Request) *DeviceDocument {
 type DeviceHandler func(id string, writer http.ResponseWriter, request *http.Request) error
 
 func (self DeviceHandler) ServeHTTPC(context web.C, writer http.ResponseWriter, request *http.Request) {
+	writer.Header().Set("Access-Control-Allow-Origin", "*")
 	deviceId := context.URLParams["id"]
 	err := self(deviceId, writer, request)
 	if err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
-sidewinderserver:
+web:
   build: .
+#  dockerfile: testDockerfile
   ports:
     - "8000:8000"
   links:

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -254,6 +254,8 @@ var _ = Describe("Endpoint", func() {
 				Expect(responseRecorder.Code).To(Equal(200))
 				Expect(responseRecorder.Body.String()).To(Equal(""))
 				Expect(responseRecorder.Header().Get("Allow")).To(Equal("POST"))
+				Expect(responseRecorder.Header().Get("Access-Control-Allow-Methods")).To(Equal("POST"))
+				Expect(responseRecorder.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"))
 			})
 		})
 		Describe("/:id", func() {
@@ -267,10 +269,24 @@ var _ = Describe("Endpoint", func() {
 					Expect(responseRecorder.Code).To(Equal(200))
 					Expect(responseRecorder.Body.String()).To(Equal(""))
 					Expect(responseRecorder.Header().Get("Allow")).To(Equal("DELETE"))
+					Expect(responseRecorder.Header().Get("Access-Control-Allow-Methods")).To(Equal("DELETE"))
+					Expect(responseRecorder.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"))
 				})
 			})
 
 			Describe("DELETE", func() {
+				It("will be allowed from any origin domain", func() {
+					deviceInfo := server.DeviceDocument{"alakazham"}
+					postRequest, _ := NewPOSTRequestWithJSON("/devices", deviceInfo)
+					goji.DefaultMux.ServeHTTP(httptest.NewRecorder(), postRequest)
+
+					recorder := httptest.NewRecorder()
+					goji.DefaultMux.ServeHTTP(recorder, NewRequest("DELETE", "/devices/alakazham"))
+
+					Expect(recorder.Code).To(Equal(200))
+					Expect(recorder.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"))
+				})
+
 				It("will delete a previously added device", func() {
 					deviceInfo := server.DeviceDocument{"alakazham"}
 					postRequest, data := NewPOSTRequestWithJSON("/devices", deviceInfo)
@@ -295,7 +311,32 @@ var _ = Describe("Endpoint", func() {
 					goji.DefaultMux.ServeHTTP(httptest.NewRecorder(), request)
 				})
 
+				Describe("OPTIONS", func() {
+					It("Lists all the provided functions.", func() {
+						request, err := http.NewRequest("OPTIONS", "/devices/"+deviceId+"/repositories", nil)
+						Expect(err).NotTo(HaveOccurred())
+
+						responseRecorder := httptest.NewRecorder()
+						goji.DefaultMux.ServeHTTP(responseRecorder, request)
+						Expect(responseRecorder.Code).To(Equal(200))
+						Expect(responseRecorder.Body.String()).To(Equal(""))
+						Expect(responseRecorder.Header().Get("Allow")).To(Equal("GET, POST"))
+						Expect(responseRecorder.Header().Get("Access-Control-Allow-Methods")).To(Equal("GET, POST"))
+						Expect(responseRecorder.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"))
+					})
+				})
+
 				Describe("GET", func() {
+					It("will be allowed from any origin domain", func() {
+						request, err := http.NewRequest("GET", "/devices/"+deviceId+"/repositories", nil)
+						Expect(err).NotTo(HaveOccurred())
+
+						responseRecorder := httptest.NewRecorder()
+						goji.DefaultMux.ServeHTTP(responseRecorder, request)
+						Expect(responseRecorder.Code).To(Equal(200))
+						Expect(responseRecorder.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"))
+					})
+
 					It("will start by returning an empty array.", func() {
 						request, err := http.NewRequest("GET", "/devices/"+deviceId+"/repositories", nil)
 						Expect(err).NotTo(HaveOccurred())
@@ -323,6 +364,18 @@ var _ = Describe("Endpoint", func() {
 					})
 				})
 				Describe("POST", func() {
+					It("will be allowed from any origin domain", func() {
+						repositoryName := "billandted/excellentadventure"
+
+						request, _ := NewPOSTRequestWithJSON("/devices/"+deviceId+"/repositories",
+							struct{ Name string }{repositoryName})
+
+						responseRecorder := httptest.NewRecorder()
+						goji.DefaultMux.ServeHTTP(responseRecorder, request)
+						Expect(responseRecorder.Code).To(Equal(201))
+						Expect(responseRecorder.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"))
+					})
+
 					It("will return 201 and the value when successfully put", func() {
 						repositoryName := "billandted/excellentadventure"
 
@@ -361,6 +414,8 @@ var _ = Describe("Endpoint", func() {
 						Expect(responseRecorder.Code).To(Equal(200))
 						Expect(responseRecorder.Body.String()).To(Equal(""))
 						Expect(responseRecorder.Header().Get("Allow")).To(Equal("POST"))
+						Expect(responseRecorder.Header().Get("Access-Control-Allow-Methods")).To(Equal("POST"))
+						Expect(responseRecorder.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"))
 					})
 				})
 

--- a/rest.go
+++ b/rest.go
@@ -39,7 +39,10 @@ func (self *RestMux) Use(endpointHandler RestEndpointHandler) *RestMux {
 	}
 	if len(methods) > 0 {
 		self.Mux.Options(self.pattern, func(context web.C, writer http.ResponseWriter, request *http.Request) {
-			writer.Header().Set("Allow", strings.Join(methods, ","))
+			methodListString := strings.Join(methods, ", ")
+			writer.Header().Set("Allow", methodListString)
+			writer.Header().Set("Access-Control-Allow-Methods", methodListString)
+			writer.Header().Set("Access-Control-Allow-Origin", "*")
 		})
 	}
 
@@ -89,6 +92,7 @@ func (self *RestEndpoint) Route(pattern string, endpoint RestEndpoint) *RestEndp
 type RestHandler func(context web.C, writer http.ResponseWriter, request *http.Request) error
 
 func (self RestHandler) ServeHTTPC(context web.C, writer http.ResponseWriter, request *http.Request) {
+	writer.Header().Set("Access-Control-Allow-Origin", "*")
 	if err := self(context, writer, request); err != nil {
 		fmt.Printf("ERROR:  %v\n", err.Error())
 		writeJson(500, ErrorJson{err.Error()}, writer)

--- a/sidewinder_server_suite_test.go
+++ b/sidewinder_server_suite_test.go
@@ -1,7 +1,10 @@
 package main_test
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 
 	"testing"
@@ -9,5 +12,7 @@ import (
 
 func TestSidewinderServer(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "SidewinderServer Suite")
+	os.MkdirAll("test-results", 0755)
+	junitReporter := reporters.NewJUnitReporter("test-results/junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "SidewinderServer Suite", []Reporter{junitReporter})
 }

--- a/testDockerfile
+++ b/testDockerfile
@@ -4,7 +4,8 @@ RUN mkdir -p /go/src/github.com/sidewinder-team/sidewinder-server
 WORKDIR /go/src/github.com/sidewinder-team/sidewinder-server
 COPY . /go/src/github.com/sidewinder-team/sidewinder-server
 
-RUN go-wrapper download
-RUN go-wrapper install
-RUN go get -t
-RUN go test
+RUN go-wrapper download \
+  && go-wrapper install \
+  && go get github.com/onsi/ginkgo/ginkgo \
+  && go get github.com/onsi/gomega
+CMD ginkgo watch


### PR DESCRIPTION
Browsers (including our ionic app) cannot call the REST endpoints across domains unless there are some special headers that get populated on the server side.

See https://trello.com/c/BgWJtua3 and https://en.wikipedia.org/wiki/Cross-origin_resource_sharing

Starting a branch to capture the need. Feel free to pick it up and merge the PR when it's working.
